### PR TITLE
Fix the issue when user first time login to the system

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,6 +378,10 @@
                 if (err) {
                     return callback(err);
                 }
+                // Fix the issue when ldapid is not existed yet
+                if (!uid) {
+                    return callback(null, {uid:0});
+                }
                 user.getUserData(uid, (err, data) => {
                     if (err) {
                         return callback(err);


### PR DESCRIPTION
`uid` will be `null` after calling `db.getObjectField` if uid is not found corresponding to ldapid.
In this case, need to return `{uid:0}` to ask the system to create new user